### PR TITLE
chore: add scala version to artifactId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.12.12</scala.version>
-    <scala.version.short>2.12</scala.version.short>
+    <scala.version>2.11.12</scala.version>
+    <scala.version.short>2.11</scala.version.short>
     <spark.version>2.4.7</spark.version>
   </properties>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
-  <artifactId>pubsublite-spark-sql-streaming</artifactId>
+  <artifactId>pubsublite-spark-sql-streaming_${scala.version.short}</artifactId>
   <version>0.1.0-SNAPSHOT</version><!-- {x-version-update:pubsublite-spark-sql-streaming:current} -->
   <packaging>jar</packaging>
   <name>Pub/Sub Lite Spark SQL Streaming</name>
@@ -17,8 +17,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.11.12</scala.version>
-    <scala.version.short>2.11</scala.version.short>
+    <scala.version>2.12.12</scala.version>
+    <scala.version.short>2.12</scala.version.short>
     <spark.version>2.4.7</spark.version>
   </properties>
   <dependencies>


### PR DESCRIPTION
I submitted two pySpark jobs to Dataproc using fat JARs compiled with scala==2.11 and scala==2.12 (Scala 2.11 and 2.12 are not binary compatible). Both Dataproc jobs succeeded.

This change will cause the artifactId to look something like `pubsublite-spark-sql-streaming_2.12`.