### PR TITLE
feat: update artifactId for fat jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
                 </relocation>
               </relocations>
               <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>with-dependencies</shadedClassifierName>
+              <finalName>pubsublite-spark-sql-streaming-with-dependencies-${project.version}</finalName>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This moves with-dependencies before version in jar naming.

We decided to publish only one version for both scala 2.11 and 2.12 since our code is all java, and all the scala related lib are "provided" and compatible with whatever classpath provides.