### PR TITLE
feat: Add max message per batch option

### DIFF
--- a/src/main/java/com/google/cloud/pubsublite/spark/Constants.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/Constants.java
@@ -25,7 +25,6 @@ import org.apache.spark.sql.types.StructType;
 public class Constants {
   public static long DEFAULT_BYTES_OUTSTANDING = 50_000_000;
   public static long DEFAULT_MESSAGES_OUTSTANDING = Long.MAX_VALUE;
-  public static long DEFAULT_BATCH_OFFSET_RANGE = Long.MAX_VALUE;
   public static StructType DEFAULT_SCHEMA =
       new StructType(
           new StructField[] {
@@ -46,7 +45,8 @@ public class Constants {
 
   public static final PubsubContext.Framework FRAMEWORK = PubsubContext.Framework.of("SPARK");
 
-  public static String BATCH_OFFSET_RANGE_CONFIG_KEY = "pubsublite.flowcontrol.batchoffsetrange";
+  public static String MAX_MESSAGE_PER_BATCH_CONFIG_KEY =
+      "pubsublite.flowcontrol.maxmessageperbatch";
   public static String BYTES_OUTSTANDING_CONFIG_KEY =
       "pubsublite.flowcontrol.byteoutstandingperpartition";
   public static String MESSAGES_OUTSTANDING_CONFIG_KEY =

--- a/src/main/java/com/google/cloud/pubsublite/spark/Constants.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/Constants.java
@@ -25,6 +25,7 @@ import org.apache.spark.sql.types.StructType;
 public class Constants {
   public static long DEFAULT_BYTES_OUTSTANDING = 50_000_000;
   public static long DEFAULT_MESSAGES_OUTSTANDING = Long.MAX_VALUE;
+  public static long DEFAULT_MAX_MESSAGES_PER_BATCH = Long.MAX_VALUE;
   public static StructType DEFAULT_SCHEMA =
       new StructType(
           new StructField[] {
@@ -46,7 +47,7 @@ public class Constants {
   public static final PubsubContext.Framework FRAMEWORK = PubsubContext.Framework.of("SPARK");
 
   public static String MAX_MESSAGE_PER_BATCH_CONFIG_KEY =
-      "pubsublite.flowcontrol.maxmessageperbatch";
+      "pubsublite.flowcontrol.maxmessagesperbatch";
   public static String BYTES_OUTSTANDING_CONFIG_KEY =
       "pubsublite.flowcontrol.byteoutstandingperpartition";
   public static String MESSAGES_OUTSTANDING_CONFIG_KEY =

--- a/src/main/java/com/google/cloud/pubsublite/spark/Constants.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/Constants.java
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.StructType;
 public class Constants {
   public static long DEFAULT_BYTES_OUTSTANDING = 50_000_000;
   public static long DEFAULT_MESSAGES_OUTSTANDING = Long.MAX_VALUE;
-  public static int DEFAULT_BATCH_OFFSET_RANGE = 100_000;
+  public static long DEFAULT_BATCH_OFFSET_RANGE = Long.MAX_VALUE;
   public static StructType DEFAULT_SCHEMA =
       new StructType(
           new StructField[] {
@@ -46,6 +46,8 @@ public class Constants {
 
   public static final PubsubContext.Framework FRAMEWORK = PubsubContext.Framework.of("SPARK");
 
+  public static String BATCH_OFFSET_RANGE_CONFIG_KEY =
+          "pubsublite.flowcontrol.batchoffsetrange";
   public static String BYTES_OUTSTANDING_CONFIG_KEY =
       "pubsublite.flowcontrol.byteoutstandingperpartition";
   public static String MESSAGES_OUTSTANDING_CONFIG_KEY =

--- a/src/main/java/com/google/cloud/pubsublite/spark/Constants.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/Constants.java
@@ -46,8 +46,7 @@ public class Constants {
 
   public static final PubsubContext.Framework FRAMEWORK = PubsubContext.Framework.of("SPARK");
 
-  public static String BATCH_OFFSET_RANGE_CONFIG_KEY =
-          "pubsublite.flowcontrol.batchoffsetrange";
+  public static String BATCH_OFFSET_RANGE_CONFIG_KEY = "pubsublite.flowcontrol.batchoffsetrange";
   public static String BYTES_OUTSTANDING_CONFIG_KEY =
       "pubsublite.flowcontrol.byteoutstandingperpartition";
   public static String MESSAGES_OUTSTANDING_CONFIG_KEY =

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
@@ -98,6 +98,7 @@ public final class PslDataSource
             Ticker.systemTicker()),
         subscriptionPath,
         Objects.requireNonNull(pslDataSourceOptions.flowControlSettings()),
+        pslDataSourceOptions.maxBatchOffsetRange(),
         topicPartitionCount);
   }
 }

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
@@ -98,7 +98,7 @@ public final class PslDataSource
             Ticker.systemTicker()),
         subscriptionPath,
         Objects.requireNonNull(pslDataSourceOptions.flowControlSettings()),
-        pslDataSourceOptions.maxBatchOffsetRange(),
+        Objects.requireNonNull(pslDataSourceOptions.maxBatchOffsetRange()),
         topicPartitionCount);
   }
 }

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
@@ -98,7 +98,7 @@ public final class PslDataSource
             Ticker.systemTicker()),
         subscriptionPath,
         Objects.requireNonNull(pslDataSourceOptions.flowControlSettings()),
-        Objects.requireNonNull(pslDataSourceOptions.maxBatchOffsetRange()),
+        pslDataSourceOptions.maxMessagePerBatch(),
         topicPartitionCount);
   }
 }

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
@@ -98,7 +98,7 @@ public final class PslDataSource
             Ticker.systemTicker()),
         subscriptionPath,
         Objects.requireNonNull(pslDataSourceOptions.flowControlSettings()),
-        pslDataSourceOptions.maxMessagePerBatch(),
+        pslDataSourceOptions.maxMessagesPerBatch(),
         topicPartitionCount);
   }
 }

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
@@ -42,7 +42,6 @@ import com.google.cloud.pubsublite.v1.TopicStatsServiceClient;
 import com.google.cloud.pubsublite.v1.TopicStatsServiceSettings;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
 
@@ -58,11 +57,11 @@ public abstract class PslDataSourceOptions implements Serializable {
   @Nullable
   public abstract FlowControlSettings flowControlSettings();
 
-  @Nullable
-  public abstract Long maxMessagePerBatch();
+  public abstract long maxMessagesPerBatch();
 
   public static Builder builder() {
-    return new AutoValue_PslDataSourceOptions.Builder().setCredentialsKey(null);
+    return new AutoValue_PslDataSourceOptions.Builder().setCredentialsKey(null)
+            .setMaxMessagesPerBatch(Constants.DEFAULT_MAX_MESSAGES_PER_BATCH);
   }
 
   public static PslDataSourceOptions fromSparkDataSourceOptions(DataSourceOptions options) {
@@ -71,14 +70,9 @@ public abstract class PslDataSourceOptions implements Serializable {
     }
 
     Builder builder = builder();
-    Optional<String> cred;
-    if ((cred = options.get(Constants.CREDENTIALS_KEY_CONFIG_KEY)).isPresent()) {
-      builder.setCredentialsKey(cred.get());
-    }
-    Optional<String> bor;
-    if ((bor = options.get(Constants.MAX_MESSAGE_PER_BATCH_CONFIG_KEY)).isPresent()) {
-      builder.setMaxMessagePerBatch(Long.parseLong(bor.get()));
-    }
+    options.get(Constants.CREDENTIALS_KEY_CONFIG_KEY).ifPresent(builder::setCredentialsKey);
+    options.get(Constants.MAX_MESSAGE_PER_BATCH_CONFIG_KEY).ifPresent(mmpb ->
+            builder.setMaxMessagesPerBatch(Long.parseLong(mmpb)));
     return builder
         .setSubscriptionPath(
             SubscriptionPath.parse(options.get(Constants.SUBSCRIPTION_CONFIG_KEY).get()))
@@ -103,7 +97,7 @@ public abstract class PslDataSourceOptions implements Serializable {
 
     public abstract Builder setSubscriptionPath(SubscriptionPath subscriptionPath);
 
-    public abstract Builder setMaxMessagePerBatch(long maxMessagePerBatch);
+    public abstract Builder setMaxMessagesPerBatch(long maxMessagesPerBatch);
 
     public abstract Builder setFlowControlSettings(FlowControlSettings flowControlSettings);
 

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
@@ -62,11 +62,7 @@ public abstract class PslDataSourceOptions implements Serializable {
 
   public static Builder builder() {
     return new AutoValue_PslDataSourceOptions.Builder()
-        .setCredentialsKey(null)
-        // TODO(jiangmichael): Revisit this later about if we need to expose this as a user
-        // configurable option. Ideally we should expose bytes range/# msgs range not
-        // offsets range since PSL doesn't guarantee offset = msg.
-        .setMaxBatchOffsetRange(Constants.DEFAULT_BATCH_OFFSET_RANGE);
+        .setCredentialsKey(null);
   }
 
   public static PslDataSourceOptions fromSparkDataSourceOptions(DataSourceOptions options) {
@@ -93,6 +89,9 @@ public abstract class PslDataSourceOptions implements Serializable {
                         Constants.BYTES_OUTSTANDING_CONFIG_KEY,
                         Constants.DEFAULT_BYTES_OUTSTANDING))
                 .build())
+        .setMaxBatchOffsetRange(options.getLong(
+                Constants.BATCH_OFFSET_RANGE_CONFIG_KEY,
+                Constants.DEFAULT_BATCH_OFFSET_RANGE))
         .build();
   }
 

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
@@ -16,15 +16,22 @@
 
 package com.google.cloud.pubsublite.spark;
 
-import static com.google.cloud.pubsublite.internal.wire.ServiceClients.addDefaultSettings;
+import static com.google.cloud.pubsublite.internal.ExtractStatus.toCanonical;
 
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.FixedExecutorProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ClientSettings;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
+import com.google.cloud.pubsublite.CloudRegion;
 import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.cloud.pubsublite.internal.CursorClient;
 import com.google.cloud.pubsublite.internal.CursorClientSettings;
+import com.google.cloud.pubsublite.internal.Lazy;
 import com.google.cloud.pubsublite.internal.TopicStatsClient;
 import com.google.cloud.pubsublite.internal.TopicStatsClientSettings;
 import com.google.cloud.pubsublite.internal.wire.CommitterBuilder;
@@ -40,11 +47,14 @@ import com.google.cloud.pubsublite.v1.SubscriberServiceClient;
 import com.google.cloud.pubsublite.v1.SubscriberServiceSettings;
 import com.google.cloud.pubsublite.v1.TopicStatsServiceClient;
 import com.google.cloud.pubsublite.v1.TopicStatsServiceSettings;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import javax.annotation.Nullable;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
+import org.threeten.bp.Duration;
 
 @AutoValue
 public abstract class PslDataSourceOptions implements Serializable {
@@ -58,11 +68,11 @@ public abstract class PslDataSourceOptions implements Serializable {
   @Nullable
   public abstract FlowControlSettings flowControlSettings();
 
-  public abstract long maxBatchOffsetRange();
+  @Nullable
+  public abstract Long maxBatchOffsetRange();
 
   public static Builder builder() {
-    return new AutoValue_PslDataSourceOptions.Builder()
-        .setCredentialsKey(null);
+    return new AutoValue_PslDataSourceOptions.Builder().setCredentialsKey(null);
   }
 
   public static PslDataSourceOptions fromSparkDataSourceOptions(DataSourceOptions options) {
@@ -89,9 +99,9 @@ public abstract class PslDataSourceOptions implements Serializable {
                         Constants.BYTES_OUTSTANDING_CONFIG_KEY,
                         Constants.DEFAULT_BYTES_OUTSTANDING))
                 .build())
-        .setMaxBatchOffsetRange(options.getLong(
-                Constants.BATCH_OFFSET_RANGE_CONFIG_KEY,
-                Constants.DEFAULT_BATCH_OFFSET_RANGE))
+        .setMaxBatchOffsetRange(
+            options.getLong(
+                Constants.BATCH_OFFSET_RANGE_CONFIG_KEY, Constants.DEFAULT_BATCH_OFFSET_RANGE))
         .build();
   }
 

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
@@ -54,14 +54,21 @@ public abstract class PslDataSourceOptions implements Serializable {
 
   public abstract SubscriptionPath subscriptionPath();
 
-  @Nullable
   public abstract FlowControlSettings flowControlSettings();
 
   public abstract long maxMessagesPerBatch();
 
   public static Builder builder() {
     return new AutoValue_PslDataSourceOptions.Builder().setCredentialsKey(null)
-            .setMaxMessagesPerBatch(Constants.DEFAULT_MAX_MESSAGES_PER_BATCH);
+            .setMaxMessagesPerBatch(Constants.DEFAULT_MAX_MESSAGES_PER_BATCH)
+            .setFlowControlSettings(
+                    FlowControlSettings.builder()
+                            .setMessagesOutstanding(
+                                            Constants.DEFAULT_MESSAGES_OUTSTANDING)
+                            .setBytesOutstanding(
+                                    Constants.DEFAULT_BYTES_OUTSTANDING)
+                            .build()
+            );
   }
 
   public static PslDataSourceOptions fromSparkDataSourceOptions(DataSourceOptions options) {

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSourceOptions.java
@@ -59,16 +59,14 @@ public abstract class PslDataSourceOptions implements Serializable {
   public abstract long maxMessagesPerBatch();
 
   public static Builder builder() {
-    return new AutoValue_PslDataSourceOptions.Builder().setCredentialsKey(null)
-            .setMaxMessagesPerBatch(Constants.DEFAULT_MAX_MESSAGES_PER_BATCH)
-            .setFlowControlSettings(
-                    FlowControlSettings.builder()
-                            .setMessagesOutstanding(
-                                            Constants.DEFAULT_MESSAGES_OUTSTANDING)
-                            .setBytesOutstanding(
-                                    Constants.DEFAULT_BYTES_OUTSTANDING)
-                            .build()
-            );
+    return new AutoValue_PslDataSourceOptions.Builder()
+        .setCredentialsKey(null)
+        .setMaxMessagesPerBatch(Constants.DEFAULT_MAX_MESSAGES_PER_BATCH)
+        .setFlowControlSettings(
+            FlowControlSettings.builder()
+                .setMessagesOutstanding(Constants.DEFAULT_MESSAGES_OUTSTANDING)
+                .setBytesOutstanding(Constants.DEFAULT_BYTES_OUTSTANDING)
+                .build());
   }
 
   public static PslDataSourceOptions fromSparkDataSourceOptions(DataSourceOptions options) {
@@ -78,8 +76,9 @@ public abstract class PslDataSourceOptions implements Serializable {
 
     Builder builder = builder();
     options.get(Constants.CREDENTIALS_KEY_CONFIG_KEY).ifPresent(builder::setCredentialsKey);
-    options.get(Constants.MAX_MESSAGE_PER_BATCH_CONFIG_KEY).ifPresent(mmpb ->
-            builder.setMaxMessagesPerBatch(Long.parseLong(mmpb)));
+    options
+        .get(Constants.MAX_MESSAGE_PER_BATCH_CONFIG_KEY)
+        .ifPresent(mmpb -> builder.setMaxMessagesPerBatch(Long.parseLong(mmpb)));
     return builder
         .setSubscriptionPath(
             SubscriptionPath.parse(options.get(Constants.SUBSCRIPTION_CONFIG_KEY).get()))

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchInputPartitionReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchInputPartitionReader.java
@@ -66,10 +66,10 @@ public class PslMicroBatchInputPartitionReader implements InputPartitionReader<I
       } catch (TimeoutException e) {
         log.atWarning().log(
             String.format(
-                "Unable to get any messages in last %s. Partition: %d; Current message offset: %d; End message offset: %d.",
+                "Unable to get any messages in last %s. Partition: %d; Current message offset: %s; End message offset: %d.",
                 SUBSCRIBER_PULL_TIMEOUT.toString(),
                 endOffset.partition().value(),
-                currentMsg != null ? currentMsg.offset().value() : null,
+                currentMsg == null ? "null" : currentMsg.offset().value(),
                 endOffset.offset()));
       } catch (Throwable t) {
         throw new IllegalStateException("Failed to retrieve messages.", t);

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchInputPartitionReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchInputPartitionReader.java
@@ -64,7 +64,13 @@ public class PslMicroBatchInputPartitionReader implements InputPartitionReader<I
         msg = subscriber.messageIfAvailable();
         break;
       } catch (TimeoutException e) {
-        log.atWarning().log("Unable to get any messages in last " + SUBSCRIBER_PULL_TIMEOUT);
+        log.atWarning().log(
+            String.format(
+                "Unable to get any messages in last %s. Partition: %d; Current message offset: %d; End message offset: %d.",
+                SUBSCRIBER_PULL_TIMEOUT.toString(),
+                endOffset.partition().value(),
+                currentMsg != null ? currentMsg.offset().value() : null,
+                endOffset.offset()));
       } catch (Throwable t) {
         throw new IllegalStateException("Failed to retrieve messages.", t);
       }

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
@@ -42,7 +42,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
   private final SubscriptionPath subscriptionPath;
   private final FlowControlSettings flowControlSettings;
   private final long topicPartitionCount;
-  @Nullable private final Long maxMessagePerBatch;
+  private final long maxMessagesPerBatch;
   @Nullable private SparkSourceOffset startOffset = null;
   private SparkSourceOffset endOffset;
 
@@ -53,7 +53,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
       PerTopicHeadOffsetReader headOffsetReader,
       SubscriptionPath subscriptionPath,
       FlowControlSettings flowControlSettings,
-      @Nullable Long maxMessagePerBatch,
+      long maxMessagesPerBatch,
       long topicPartitionCount) {
     this.cursorClient = cursorClient;
     this.committer = committer;
@@ -62,7 +62,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
     this.subscriptionPath = subscriptionPath;
     this.flowControlSettings = flowControlSettings;
     this.topicPartitionCount = topicPartitionCount;
-    this.maxMessagePerBatch = maxMessagePerBatch;
+    this.maxMessagesPerBatch = maxMessagesPerBatch;
   }
 
   @Override
@@ -86,7 +86,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
           PslSparkUtils.toSparkSourceOffset(headOffsetReader.getHeadOffset());
       endOffset =
           PslSparkUtils.getSparkEndOffset(
-              headOffset, startOffset, maxMessagePerBatch, topicPartitionCount);
+              headOffset, startOffset, maxMessagesPerBatch, topicPartitionCount);
     }
   }
 

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
@@ -42,6 +42,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
   private final SubscriptionPath subscriptionPath;
   private final FlowControlSettings flowControlSettings;
   private final long topicPartitionCount;
+  private final long batchOffsetRange;
   @Nullable private SparkSourceOffset startOffset = null;
   private SparkSourceOffset endOffset;
 
@@ -52,6 +53,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
       PerTopicHeadOffsetReader headOffsetReader,
       SubscriptionPath subscriptionPath,
       FlowControlSettings flowControlSettings,
+      long batchOffsetRange,
       long topicPartitionCount) {
     this.cursorClient = cursorClient;
     this.committer = committer;
@@ -60,6 +62,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
     this.subscriptionPath = subscriptionPath;
     this.flowControlSettings = flowControlSettings;
     this.topicPartitionCount = topicPartitionCount;
+    this.batchOffsetRange = batchOffsetRange;
   }
 
   @Override
@@ -79,7 +82,8 @@ public class PslMicroBatchReader implements MicroBatchReader {
           "end offset is not instance of SparkSourceOffset.");
       endOffset = (SparkSourceOffset) end.get();
     } else {
-      endOffset = PslSparkUtils.toSparkSourceOffset(headOffsetReader.getHeadOffset());
+      SparkSourceOffset headOffset = PslSparkUtils.toSparkSourceOffset(headOffsetReader.getHeadOffset());
+      endOffset = PslSparkUtils.getSparkEndOffset(headOffset, startOffset, batchOffsetRange, topicPartitionCount);
     }
   }
 

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
@@ -42,7 +42,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
   private final SubscriptionPath subscriptionPath;
   private final FlowControlSettings flowControlSettings;
   private final long topicPartitionCount;
-  private final long batchOffsetRange;
+  @Nullable private final Long maxMessagePerBatch;
   @Nullable private SparkSourceOffset startOffset = null;
   private SparkSourceOffset endOffset;
 
@@ -53,7 +53,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
       PerTopicHeadOffsetReader headOffsetReader,
       SubscriptionPath subscriptionPath,
       FlowControlSettings flowControlSettings,
-      long batchOffsetRange,
+      @Nullable Long maxMessagePerBatch,
       long topicPartitionCount) {
     this.cursorClient = cursorClient;
     this.committer = committer;
@@ -62,7 +62,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
     this.subscriptionPath = subscriptionPath;
     this.flowControlSettings = flowControlSettings;
     this.topicPartitionCount = topicPartitionCount;
-    this.batchOffsetRange = batchOffsetRange;
+    this.maxMessagePerBatch = maxMessagePerBatch;
   }
 
   @Override
@@ -86,7 +86,7 @@ public class PslMicroBatchReader implements MicroBatchReader {
           PslSparkUtils.toSparkSourceOffset(headOffsetReader.getHeadOffset());
       endOffset =
           PslSparkUtils.getSparkEndOffset(
-              headOffset, startOffset, batchOffsetRange, topicPartitionCount);
+              headOffset, startOffset, maxMessagePerBatch, topicPartitionCount);
     }
   }
 

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
@@ -82,8 +82,11 @@ public class PslMicroBatchReader implements MicroBatchReader {
           "end offset is not instance of SparkSourceOffset.");
       endOffset = (SparkSourceOffset) end.get();
     } else {
-      SparkSourceOffset headOffset = PslSparkUtils.toSparkSourceOffset(headOffsetReader.getHeadOffset());
-      endOffset = PslSparkUtils.getSparkEndOffset(headOffset, startOffset, batchOffsetRange, topicPartitionCount);
+      SparkSourceOffset headOffset =
+          PslSparkUtils.toSparkSourceOffset(headOffsetReader.getHeadOffset());
+      endOffset =
+          PslSparkUtils.getSparkEndOffset(
+              headOffset, startOffset, batchOffsetRange, topicPartitionCount);
     }
   }
 

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslSparkUtils.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslSparkUtils.java
@@ -146,8 +146,10 @@ public class PslSparkUtils {
       SparkPartitionOffset emptyPartition = SparkPartitionOffset.create(p, -1L);
       long head = headOffset.getPartitionOffsetMap().getOrDefault(p, emptyPartition).offset();
       long start = startOffset.getPartitionOffsetMap().getOrDefault(p, emptyPartition).offset();
-      map.put(p, SparkPartitionOffset.create(p,
-              Math.min(LongMath.saturatedAdd(start, maxMessagesPerBatch), head)));
+      map.put(
+          p,
+          SparkPartitionOffset.create(
+              p, Math.min(LongMath.saturatedAdd(start, maxMessagesPerBatch), head)));
     }
     return new SparkSourceOffset(map);
   }

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslSparkUtils.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslSparkUtils.java
@@ -134,8 +134,11 @@ public class PslSparkUtils {
   }
 
   // EndOffset = min(startOffset + batchOffsetRange, headOffset)
-  public static SparkSourceOffset getSparkEndOffset(SparkSourceOffset headOffset, SparkSourceOffset startOffset,
-                                                    long batchOffsetRange, long topicPartitionCount) {
+  public static SparkSourceOffset getSparkEndOffset(
+      SparkSourceOffset headOffset,
+      SparkSourceOffset startOffset,
+      long batchOffsetRange,
+      long topicPartitionCount) {
     Map<Partition, SparkPartitionOffset> map = new HashMap<>();
     for (int i = 0; i < topicPartitionCount; i++) {
       Partition p = Partition.of(i);

--- a/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
@@ -40,7 +40,7 @@ public class PslMicroBatchReaderTest {
   private final PartitionSubscriberFactory partitionSubscriberFactory =
       mock(PartitionSubscriberFactory.class);
   private final PerTopicHeadOffsetReader headOffsetReader = mock(PerTopicHeadOffsetReader.class);
-  private final long maxMessagesPerBatch = 20000;
+  private static final long MAX_MESSAGES_PER_BATCH = 20000;
   private final PslMicroBatchReader reader =
       new PslMicroBatchReader(
           cursorClient,
@@ -49,7 +49,7 @@ public class PslMicroBatchReaderTest {
           headOffsetReader,
           UnitTestExamples.exampleSubscriptionPath(),
           OPTIONS.flowControlSettings(),
-          maxMessagesPerBatch,
+          MAX_MESSAGES_PER_BATCH,
           2);
 
   private PslSourceOffset createPslSourceOffsetTwoPartition(long offset0, long offset1) {
@@ -135,7 +135,7 @@ public class PslMicroBatchReaderTest {
             // the maxMessagesPerBatch setting takes effect as 100L + maxMessagesPerBatch is less
             // than
             // 10000000L.
-            SparkPartitionOffset.create(Partition.of(0L), 100L + maxMessagesPerBatch - 1L),
+            SparkPartitionOffset.create(Partition.of(0L), 100L + MAX_MESSAGES_PER_BATCH - 1L),
             Partition.of(1L),
             SparkPartitionOffset.create(Partition.of(1L), -1L));
   }

--- a/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
@@ -123,7 +123,7 @@ public class PslMicroBatchReaderTest {
   }
 
   @Test
-  public void testmaxMessagesPerBatch() {
+  public void testMaxMessagesPerBatch() {
     when(cursorClient.listPartitionCursors(UnitTestExamples.exampleSubscriptionPath()))
         .thenReturn(ApiFutures.immediateFuture(ImmutableMap.of(Partition.of(0L), Offset.of(100L))));
     when(headOffsetReader.getHeadOffset())

--- a/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
@@ -132,7 +132,7 @@ public class PslMicroBatchReaderTest {
     assertThat(((SparkSourceOffset) reader.getEndOffset()).getPartitionOffsetMap())
         .containsExactly(
             Partition.of(0L),
-            //
+            // the BatchOffsetRange setting takes effect as 100L + batchOffsetRange is less than 10000000L.
             SparkPartitionOffset.create(Partition.of(0L), 100L + batchOffsetRange - 1L),
             Partition.of(1L),
             SparkPartitionOffset.create(Partition.of(1L), -1L));

--- a/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
@@ -40,7 +40,7 @@ public class PslMicroBatchReaderTest {
   private final PartitionSubscriberFactory partitionSubscriberFactory =
       mock(PartitionSubscriberFactory.class);
   private final PerTopicHeadOffsetReader headOffsetReader = mock(PerTopicHeadOffsetReader.class);
-  private final long maxMessagePerBatch = 20000;
+  private final long maxMessagesPerBatch = 20000;
   private final PslMicroBatchReader reader =
       new PslMicroBatchReader(
           cursorClient,
@@ -49,7 +49,7 @@ public class PslMicroBatchReaderTest {
           headOffsetReader,
           UnitTestExamples.exampleSubscriptionPath(),
           OPTIONS.flowControlSettings(),
-          maxMessagePerBatch,
+          maxMessagesPerBatch,
           2);
 
   private PslSourceOffset createPslSourceOffsetTwoPartition(long offset0, long offset1) {
@@ -123,7 +123,7 @@ public class PslMicroBatchReaderTest {
   }
 
   @Test
-  public void testMaxMessagePerBatch() {
+  public void testmaxMessagesPerBatch() {
     when(cursorClient.listPartitionCursors(UnitTestExamples.exampleSubscriptionPath()))
         .thenReturn(ApiFutures.immediateFuture(ImmutableMap.of(Partition.of(0L), Offset.of(100L))));
     when(headOffsetReader.getHeadOffset())
@@ -132,9 +132,9 @@ public class PslMicroBatchReaderTest {
     assertThat(((SparkSourceOffset) reader.getEndOffset()).getPartitionOffsetMap())
         .containsExactly(
             Partition.of(0L),
-            // the maxMessagePerBatch setting takes effect as 100L + maxMessagePerBatch is less than
+            // the maxMessagesPerBatch setting takes effect as 100L + maxMessagesPerBatch is less than
             // 10000000L.
-            SparkPartitionOffset.create(Partition.of(0L), 100L + maxMessagePerBatch - 1L),
+            SparkPartitionOffset.create(Partition.of(0L), 100L + maxMessagesPerBatch - 1L),
             Partition.of(1L),
             SparkPartitionOffset.create(Partition.of(1L), -1L));
   }

--- a/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
@@ -40,7 +40,7 @@ public class PslMicroBatchReaderTest {
   private final PartitionSubscriberFactory partitionSubscriberFactory =
       mock(PartitionSubscriberFactory.class);
   private final PerTopicHeadOffsetReader headOffsetReader = mock(PerTopicHeadOffsetReader.class);
-  private final long batchOffsetRange = 20000;
+  private final long maxMessagePerBatch = 20000;
   private final PslMicroBatchReader reader =
       new PslMicroBatchReader(
           cursorClient,
@@ -49,7 +49,7 @@ public class PslMicroBatchReaderTest {
           headOffsetReader,
           UnitTestExamples.exampleSubscriptionPath(),
           OPTIONS.flowControlSettings(),
-          batchOffsetRange,
+          maxMessagePerBatch,
           2);
 
   private PslSourceOffset createPslSourceOffsetTwoPartition(long offset0, long offset1) {
@@ -132,8 +132,9 @@ public class PslMicroBatchReaderTest {
     assertThat(((SparkSourceOffset) reader.getEndOffset()).getPartitionOffsetMap())
         .containsExactly(
             Partition.of(0L),
-            // the BatchOffsetRange setting takes effect as 100L + batchOffsetRange is less than 10000000L.
-            SparkPartitionOffset.create(Partition.of(0L), 100L + batchOffsetRange - 1L),
+            // the maxMessagePerBatch setting takes effect as 100L + maxMessagePerBatch is less than
+            // 10000000L.
+            SparkPartitionOffset.create(Partition.of(0L), 100L + maxMessagePerBatch - 1L),
             Partition.of(1L),
             SparkPartitionOffset.create(Partition.of(1L), -1L));
   }

--- a/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
@@ -132,7 +132,8 @@ public class PslMicroBatchReaderTest {
     assertThat(((SparkSourceOffset) reader.getEndOffset()).getPartitionOffsetMap())
         .containsExactly(
             Partition.of(0L),
-            // the maxMessagesPerBatch setting takes effect as 100L + maxMessagesPerBatch is less than
+            // the maxMessagesPerBatch setting takes effect as 100L + maxMessagesPerBatch is less
+            // than
             // 10000000L.
             SparkPartitionOffset.create(Partition.of(0L), 100L + maxMessagesPerBatch - 1L),
             Partition.of(1L),

--- a/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
@@ -123,7 +123,7 @@ public class PslMicroBatchReaderTest {
   }
 
   @Test
-  public void testBatchOffsetRange() {
+  public void testMaxMessagePerBatch() {
     when(cursorClient.listPartitionCursors(UnitTestExamples.exampleSubscriptionPath()))
         .thenReturn(ApiFutures.immediateFuture(ImmutableMap.of(Partition.of(0L), Offset.of(100L))));
     when(headOffsetReader.getHeadOffset())


### PR DESCRIPTION
With only PSL flow control, it's not enough to stop Spark executors from OOMing when the batch is large (large backlog). This adds support for hard limiting the max message per batch.

Note that startOffset + batch_offset_range might land on a non-message offset. Under the assumptions that headoffset - 1 is a message offset (the only corner case is broker ungracefully shut down and no new message to unblock), startOffset + batch_offset_range will be unblocked even if it is not a non-message offset.

Staging tested that adding this new option it won't OOM anymore. 

EDIT: actually kafka has same parameter https://screenshot.googleplex.com/57nu34SUfMvcRr5. 