### PR TITLE
chore: delete java7.cfg

### DIFF
--- a/.kokoro/nightly/java7.cfg
+++ b/.kokoro/nightly/java7.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/java7"
-}


### PR DESCRIPTION
Remove unit test for Java 7 from nightly.  Also see internal cl/353060067.