### PR TITLE
fix: update synth.py

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -19,4 +19,5 @@ import synthtool.languages.java as java
 java.common_templates(excludes=[
     # TODO: allow when pubsublite-spark is available in libraries-bom
     'samples/install-without-bom/*',
+    '.kokoro/build.sh',
 ])


### PR DESCRIPTION
This is to prevent synthtool from overwriting changes that we intend to keep.
 
Otherwise, synthtool will keep suggesting PRs like #58.