### PR TITLE
test: Fixes integration test nightly build.

### DIFF
--- a/samples/snippets/src/test/java/pubsublite/spark/SampleIntegrationTest.java
+++ b/samples/snippets/src/test/java/pubsublite/spark/SampleIntegrationTest.java
@@ -218,7 +218,9 @@ public class SampleIntegrationTest {
             .build();
     clusterName = env.get(CLUSTER_NAME);
     bucketName = env.get(BUCKET_NAME);
-    workingDir = System.getProperty("user.dir").replace("/samples/snapshot", "");
+    workingDir = System.getProperty("user.dir")
+            .replace("/samples/snapshot", "")
+            .replace("/samples/snippets", "");
     sampleVersion = env.get(SAMPLE_VERSION);
     connectorVersion = env.get(CONNECTOR_VERSION);
     sampleJarName = String.format("pubsublite-spark-snippets-%s.jar", sampleVersion);


### PR DESCRIPTION
Fixes https://github.com/googleapis/java-pubsublite-spark/issues/64.

The fix makes sure no matter it starts from snapshot or snippets, it will get the right pom location https://screenshot.googleplex.com/7dU7uCw3RKtLRx6.