### PR TITLE
release: Update uber jar shadedClassifierName

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
                 </relocation>
               </relocations>
               <shadedArtifactAttached>true</shadedArtifactAttached>
-              <finalName>pubsublite-spark-sql-streaming-with-dependencies-${project.version}</finalName>
+              <shadedClassifierName>with-dependencies</shadedClassifierName>
             </configuration>
           </execution>
         </executions>

--- a/samples/snippets/src/test/java/pubsublite/spark/SampleIntegrationTest.java
+++ b/samples/snippets/src/test/java/pubsublite/spark/SampleIntegrationTest.java
@@ -223,11 +223,11 @@ public class SampleIntegrationTest {
     connectorVersion = env.get(CONNECTOR_VERSION);
     sampleJarName = String.format("pubsublite-spark-snippets-%s.jar", sampleVersion);
     connectorJarName =
-        String.format("pubsublite-spark-sql-streaming-with-dependencies-%s.jar", connectorVersion);
+        String.format("pubsublite-spark-sql-streaming-%s-with-dependencies.jar", connectorVersion);
     sampleJarNameInGCS = String.format("pubsublite-spark-snippets-%s-%s.jar", sampleVersion, runId);
     connectorJarNameInGCS =
         String.format(
-            "pubsublite-spark-sql-streaming-with-dependencies-%s-%s.jar", connectorVersion, runId);
+            "pubsublite-spark-sql-streaming-%s-with-dependencies-%s.jar", connectorVersion, runId);
     sampleJarLoc = String.format("%s/samples/snippets/target/%s", workingDir, sampleJarName);
     connectorJarLoc = String.format("%s/target/%s", workingDir, connectorJarName);
   }


### PR DESCRIPTION
If I am using `<finalName>`, the jar `mvn package` generated looks good - `pubsublite-spark-sql-streaming-with-dependencies-0.1.0-SNAPSHOT.jar` but when `mvn install` it doesn't respect the jar name (https://screenshot.googleplex.com/BxKeEvS7PyfYhzd) and thus the jar name in oss.sonatype is `pubsublite-spark-sql-streaming-0.1.0-SNAPSHOT-shaded.jar`.

I switched to use `<shadedClassifierName>` and this seems to be the *only* field that `mvn install` would respect, it would generate `pubsublite-spark-sql-streaming-0.1.0-SNAPSHOT-with-dependencies.jar` in oss.sonatype, and maven would think it as 
```
<dependency>
  <groupId>com.google.cloud</groupId>
  <artifactId>pubsublite-spark-sql-streaming<artifactId>
  <version>0.1.0-SNAPSHOT</version>
  <classifier>with-dependencies</classifier>
<dependency>
```