### PR TITLE
test: Fix flakiness of integration test by ordering column.

### DIFF
--- a/samples/snippets/src/main/java/pubsublite/spark/WordCount.java
+++ b/samples/snippets/src/main/java/pubsublite/spark/WordCount.java
@@ -42,7 +42,7 @@ public class WordCount {
         df.withColumn("word", splitCol.getItem(0))
             .withColumn("word_count", splitCol.getItem(1).cast(DataTypes.LongType));
     df = df.groupBy("word").sum("word_count");
-    df = df.orderBy(df.col("sum(word_count)").desc());
+    df = df.orderBy(df.col("sum(word_count)").desc(), df.col("word").asc());
 
     StreamingQuery query =
         df.writeStream()

--- a/samples/snippets/src/test/java/pubsublite/spark/SampleIntegrationTest.java
+++ b/samples/snippets/src/test/java/pubsublite/spark/SampleIntegrationTest.java
@@ -171,18 +171,18 @@ public class SampleIntegrationTest {
             + "|    a|              6|\n"
             + "|   in|              5|\n"
             + "| that|              5|\n"
-            + "| with|              4|\n"
             + "| soul|              4|\n"
-            + "|   us|              3|\n"
-            + "|   me|              3|\n"
-            + "| when|              3|\n"
+            + "| with|              4|\n"
+            + "|   as|              3|\n"
             + "| feel|              3|\n"
             + "| like|              3|\n"
+            + "|   me|              3|\n"
             + "|   so|              3|\n"
-            + "|   as|              3|\n"
             + "| then|              3|\n"
+            + "|   us|              3|\n"
+            + "| when|              3|\n"
             + "|which|              3|\n"
-            + "|among|              2|\n"
+            + "|   am|              2|\n"
             + "+-----+---------------+\n"
             + "only showing top 20 rows";
     assertThat(sparkJobOutput).contains(expectedWordCountResult);
@@ -218,7 +218,8 @@ public class SampleIntegrationTest {
             .build();
     clusterName = env.get(CLUSTER_NAME);
     bucketName = env.get(BUCKET_NAME);
-    workingDir = System.getProperty("user.dir")
+    workingDir =
+        System.getProperty("user.dir")
             .replace("/samples/snapshot", "")
             .replace("/samples/snippets", "");
     sampleVersion = env.get(SAMPLE_VERSION);


### PR DESCRIPTION
Fixes https://github.com/googleapis/java-pubsublite-spark/issues/64

https://screenshot.googleplex.com/8dnnXZTwgfqJ7WU it's the same but the word with word_count=3 is in different order.