### PR TITLE
docs: Update gcs public available link

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -15,8 +15,11 @@ custom_content: |
     ```
 
   ## Downloading and Using the Connector
-
-    The connector is available from the [Maven Central repository](https://search.maven.org/artifact/com.google.cloud/pubsublite-spark-sql-streaming). You can download and pass it in the `--packages` option when using the `spark-submit` command or set it via the `spark.jars.packages` [configuration property](https://spark.apache.org/docs/latest/configuration.html#available-properties).
+    The latest version of the connector is publicly available in the following link:
+    | Connector version | Link |
+    | --- | --- |
+    | 0.1.0 | `gs://spark-lib/pubsublite/pubsublite-spark-sql-streaming-0.1.0-with-dependencies.jar`([HTTP link](https://storage.googleapis.com/spark-lib/pubsublite/pubsublite-spark-sql-streaming-0.1.0-with-dependencies.jar)) |
+    The connector is also available from the [Maven Central repository](https://search.maven.org/artifact/com.google.cloud/pubsublite-spark-sql-streaming). You can download and pass it in the `--jars` option when using the `spark-submit` command.
 
   ## Compatibility
   | Connector version | Spark version |


### PR DESCRIPTION
This also gets rid of the `--packages` and  `sparks.jars.packages` since spark maven dependency management ivy doesn't respect classifier. We will switch to only publish with-dependencies w/o classifier in the near future from next release.