### PR TITLE
feat: Supports topic partition increase.

### DIFF
--- a/clirr-ignored-differences.xml
+++ b/clirr-ignored-differences.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+    <difference>
+        <differenceType>7004</differenceType>
+        <className>com/google/cloud/pubsublite/spark/*Reader</className>
+        <method>*</method>
+    </difference>
+    <difference>
+        <differenceType>7005</differenceType>
+        <className>com/google/cloud/pubsublite/spark/*Reader</className>
+        <method>*</method>
+        <to>*</to>
+    </difference>
+</differences>

--- a/src/main/java/com/google/cloud/pubsublite/spark/CachedPartitionCountReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/CachedPartitionCountReader.java
@@ -33,7 +33,7 @@ public class CachedPartitionCountReader implements PartitionCountReader {
     this.adminClient = adminClient;
     this.supplier =
         Suppliers.memoizeWithExpiration(
-            () -> PartitionLookupUtils.numPartitions(topicPath, adminClient), 10, TimeUnit.SECONDS);
+            () -> PartitionLookupUtils.numPartitions(topicPath, adminClient), 1, TimeUnit.MINUTES);
   }
 
   @Override

--- a/src/main/java/com/google/cloud/pubsublite/spark/CachedPartitionCountReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/CachedPartitionCountReader.java
@@ -1,0 +1,31 @@
+package com.google.cloud.pubsublite.spark;
+
+import com.google.cloud.pubsublite.AdminClient;
+import com.google.cloud.pubsublite.PartitionLookupUtils;
+import com.google.cloud.pubsublite.TopicPath;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.ThreadSafe;
+
+@ThreadSafe
+public class CachedPartitionCountReader implements PartitionCountReader {
+  private final AdminClient adminClient;
+  private final Supplier<Integer> supplier;
+
+  public CachedPartitionCountReader(AdminClient adminClient, TopicPath topicPath) {
+    this.adminClient = adminClient;
+    this.supplier =
+        Suppliers.memoizeWithExpiration(
+            () -> PartitionLookupUtils.numPartitions(topicPath, adminClient), 10, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public void close() {
+    adminClient.close();
+  }
+
+  public int getPartitionCount() {
+    return supplier.get();
+  }
+}

--- a/src/main/java/com/google/cloud/pubsublite/spark/CachedPartitionCountReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/CachedPartitionCountReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.pubsublite.spark;
 
 import com.google.cloud.pubsublite.AdminClient;

--- a/src/main/java/com/google/cloud/pubsublite/spark/LimitingHeadOffsetReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/LimitingHeadOffsetReader.java
@@ -29,7 +29,6 @@ import com.google.cloud.pubsublite.proto.Cursor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.MoreExecutors;
-
 import java.io.Closeable;
 import java.util.HashSet;
 import java.util.Map;

--- a/src/main/java/com/google/cloud/pubsublite/spark/LimitingHeadOffsetReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/LimitingHeadOffsetReader.java
@@ -29,6 +29,8 @@ import com.google.cloud.pubsublite.proto.Cursor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.MoreExecutors;
+
+import java.io.Closeable;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -100,15 +102,10 @@ public class LimitingHeadOffsetReader implements PerTopicHeadOffsetReader {
 
   @Override
   public void close() {
-    try {
-      topicStatsClient.close();
+    try (AutoCloseable a = topicStatsClient;
+        Closeable b = partitionCountReader) {
     } catch (Exception e) {
-      log.atWarning().withCause(e).log("Unable to close TopicStatsClient.");
-    }
-    try {
-      partitionCountReader.close();
-    } catch (Exception e) {
-      log.atWarning().withCause(e).log("Unable to close PartitionCountReader.");
+      log.atWarning().withCause(e).log("Unable to close LimitingHeadOffsetReader.");
     }
   }
 }

--- a/src/main/java/com/google/cloud/pubsublite/spark/MultiPartitionCommitterImpl.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/MultiPartitionCommitterImpl.java
@@ -25,25 +25,47 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * A {@link MultiPartitionCommitter} that lazily adjusts for partition changes when {@link
- * MultiPartitionCommitter#commit(PslSourceOffset)};
+ * MultiPartitionCommitter#commit(PslSourceOffset)} is called.
  */
 public class MultiPartitionCommitterImpl implements MultiPartitionCommitter {
   private static final GoogleLogger log = GoogleLogger.forEnclosingClass();
 
   private final CommitterFactory committerFactory;
+
+  @GuardedBy("this")
   private final Map<Partition, Committer> committerMap = new HashMap<>();
 
+  @GuardedBy("this")
+  private final Set<Partition> partitionsCleanUp = new HashSet<>();
+
+  public MultiPartitionCommitterImpl(long topicPartitionCount, CommitterFactory committerFactory) {
+    this(
+        topicPartitionCount,
+        committerFactory,
+        MoreExecutors.getExitingScheduledExecutorService(new ScheduledThreadPoolExecutor(1)));
+  }
+
   @VisibleForTesting
-  MultiPartitionCommitterImpl(long topicPartitionCount, CommitterFactory committerFactory) {
+  MultiPartitionCommitterImpl(
+      long topicPartitionCount,
+      CommitterFactory committerFactory,
+      ScheduledExecutorService executorService) {
     this.committerFactory = committerFactory;
     for (int i = 0; i < topicPartitionCount; i++) {
       Partition p = Partition.of(i);
       committerMap.put(p, createCommitter(p));
     }
+    executorService.scheduleWithFixedDelay(this::cleanUpCommitterMap, 10, 10, TimeUnit.MINUTES);
   }
 
   @Override
@@ -52,11 +74,26 @@ public class MultiPartitionCommitterImpl implements MultiPartitionCommitter {
   }
 
   /** Adjust committerMap based on the partitions that needs to be committed. */
-  public synchronized void update(PslSourceOffset offset) {
-    for (Partition p : offset.partitionOffsetMap().keySet()) {
-      if (!committerMap.containsKey(p)) {
-        committerMap.put(p, createCommitter(p));
+  private synchronized void updateCommitterMap(PslSourceOffset offset) {
+    int currentPartitions = committerMap.size();
+    int newPartitions = offset.partitionOffsetMap().size();
+
+    if (currentPartitions == newPartitions) {
+      return;
+    }
+    if (currentPartitions < newPartitions) {
+      for (int i = currentPartitions; i < newPartitions; i++) {
+        Partition p = Partition.of(i);
+        if (!committerMap.containsKey(p)) {
+          committerMap.put(p, createCommitter(p));
+        }
+        partitionsCleanUp.remove(p);
       }
+      return;
+    }
+    partitionsCleanUp.clear();
+    for (int i = newPartitions; i < currentPartitions; i++) {
+      partitionsCleanUp.add(Partition.of(i));
     }
   }
 
@@ -66,9 +103,17 @@ public class MultiPartitionCommitterImpl implements MultiPartitionCommitter {
     return committer;
   }
 
+  private synchronized void cleanUpCommitterMap() {
+    for (Partition p : partitionsCleanUp) {
+      committerMap.get(p).stopAsync();
+      committerMap.remove(p);
+    }
+    partitionsCleanUp.clear();
+  }
+
   @Override
   public synchronized void commit(PslSourceOffset offset) {
-    update(offset);
+    updateCommitterMap(offset);
     offset
         .partitionOffsetMap()
         .forEach(

--- a/src/main/java/com/google/cloud/pubsublite/spark/PartitionCountReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PartitionCountReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.pubsublite.spark;
 
 import java.io.Closeable;

--- a/src/main/java/com/google/cloud/pubsublite/spark/PartitionCountReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PartitionCountReader.java
@@ -1,0 +1,10 @@
+package com.google.cloud.pubsublite.spark;
+
+import java.io.Closeable;
+
+public interface PartitionCountReader extends Closeable {
+  int getPartitionCount();
+
+  @Override
+  void close();
+}

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslContinuousReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslContinuousReader.java
@@ -41,8 +41,9 @@ public class PslContinuousReader implements ContinuousReader {
   private final PartitionSubscriberFactory partitionSubscriberFactory;
   private final SubscriptionPath subscriptionPath;
   private final FlowControlSettings flowControlSettings;
-  private final long topicPartitionCount;
   private SparkSourceOffset startOffset;
+  private final PartitionCountReader partitionCountReader;
+  private final long topicPartitionCount;
 
   @VisibleForTesting
   public PslContinuousReader(
@@ -51,13 +52,14 @@ public class PslContinuousReader implements ContinuousReader {
       PartitionSubscriberFactory partitionSubscriberFactory,
       SubscriptionPath subscriptionPath,
       FlowControlSettings flowControlSettings,
-      long topicPartitionCount) {
+      PartitionCountReader partitionCountReader) {
     this.cursorClient = cursorClient;
     this.committer = committer;
     this.partitionSubscriberFactory = partitionSubscriberFactory;
     this.subscriptionPath = subscriptionPath;
     this.flowControlSettings = flowControlSettings;
-    this.topicPartitionCount = topicPartitionCount;
+    this.partitionCountReader = partitionCountReader;
+    this.topicPartitionCount = partitionCountReader.getPartitionCount();
   }
 
   @Override
@@ -125,5 +127,10 @@ public class PslContinuousReader implements ContinuousReader {
               flowControlSettings));
     }
     return list;
+  }
+
+  @Override
+  public boolean needsReconfiguration() {
+    return partitionCountReader.getPartitionCount() != topicPartitionCount;
   }
 }

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslDataSource.java
@@ -55,14 +55,13 @@ public final class PslDataSource
         PslDataSourceOptions.fromSparkDataSourceOptions(options);
     SubscriptionPath subscriptionPath = pslDataSourceOptions.subscriptionPath();
     TopicPath topicPath;
-    AdminClient adminClient = pslDataSourceOptions.newAdminClient();
-    try {
+    try (AdminClient adminClient = pslDataSourceOptions.newAdminClient()) {
       topicPath = TopicPath.parse(adminClient.getSubscription(subscriptionPath).get().getTopic());
     } catch (Throwable t) {
       throw toCanonical(t).underlying;
     }
     PartitionCountReader partitionCountReader =
-        new CachedPartitionCountReader(adminClient, topicPath);
+        new CachedPartitionCountReader(pslDataSourceOptions.newAdminClient(), topicPath);
     return new PslContinuousReader(
         pslDataSourceOptions.newCursorClient(),
         pslDataSourceOptions.newMultiPartitionCommitter(partitionCountReader.getPartitionCount()),
@@ -84,14 +83,13 @@ public final class PslDataSource
         PslDataSourceOptions.fromSparkDataSourceOptions(options);
     SubscriptionPath subscriptionPath = pslDataSourceOptions.subscriptionPath();
     TopicPath topicPath;
-    AdminClient adminClient = pslDataSourceOptions.newAdminClient();
-    try {
+    try (AdminClient adminClient = pslDataSourceOptions.newAdminClient()) {
       topicPath = TopicPath.parse(adminClient.getSubscription(subscriptionPath).get().getTopic());
     } catch (Throwable t) {
       throw toCanonical(t).underlying;
     }
     PartitionCountReader partitionCountReader =
-        new CachedPartitionCountReader(adminClient, topicPath);
+        new CachedPartitionCountReader(pslDataSourceOptions.newAdminClient(), topicPath);
     return new PslMicroBatchReader(
         pslDataSourceOptions.newCursorClient(),
         pslDataSourceOptions.newMultiPartitionCommitter(partitionCountReader.getPartitionCount()),

--- a/src/test/java/com/google/cloud/pubsublite/spark/MultiPartitionCommitterImplTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/MultiPartitionCommitterImplTest.java
@@ -92,7 +92,7 @@ public class MultiPartitionCommitterImplTest {
 
   @Test
   public void testPartitionChange() {
-    List<Committer> committers = new ArrayList();
+    List<Committer> committers = new ArrayList<>();
     for (int i = 0; i < 4; i++) {
       Committer committer = mock(Committer.class);
       when(committer.startAsync())

--- a/src/test/java/com/google/cloud/pubsublite/spark/MultiPartitionCommitterImplTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/MultiPartitionCommitterImplTest.java
@@ -16,117 +16,124 @@
 
 package com.google.cloud.pubsublite.spark;
 
+import static com.google.cloud.pubsublite.spark.TestingUtils.createPslSourceOffset;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.pubsublite.*;
 import com.google.cloud.pubsublite.internal.wire.Committer;
-import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class MultiPartitionCommitterImplTest {
 
-  @Test
-  public void testCommit() {
-    Committer committer1 = mock(Committer.class);
-    Committer committer2 = mock(Committer.class);
-    when(committer1.startAsync())
-        .thenReturn(committer1)
-        .thenThrow(new IllegalStateException("should only init once"));
-    when(committer2.startAsync())
-        .thenReturn(committer2)
-        .thenThrow(new IllegalStateException("should only init once"));
-    MultiPartitionCommitterImpl multiCommitter =
-        new MultiPartitionCommitterImpl(
-            2,
-            (p) -> {
-              if (p.value() == 0L) {
-                return committer1;
-              } else {
-                return committer2;
-              }
-            });
-    verify(committer1).startAsync();
-    verify(committer2).startAsync();
+  private Runnable task;
+  private List<Committer> committerList;
 
-    PslSourceOffset offset =
-        PslSourceOffset.builder()
-            .partitionOffsetMap(
-                ImmutableMap.of(
-                    Partition.of(0), Offset.of(10L),
-                    Partition.of(1), Offset.of(8L)))
-            .build();
-    SettableApiFuture<Void> future1 = SettableApiFuture.create();
-    SettableApiFuture<Void> future2 = SettableApiFuture.create();
-    when(committer1.commitOffset(eq(Offset.of(10L)))).thenReturn(future1);
-    when(committer2.commitOffset(eq(Offset.of(8L)))).thenReturn(future2);
-    multiCommitter.commit(offset);
-    verify(committer1).commitOffset(eq(Offset.of(10L)));
-    verify(committer2).commitOffset(eq(Offset.of(8L)));
-  }
-
-  @Test
-  public void testClose() {
-    Committer committer = mock(Committer.class);
-    when(committer.startAsync())
-        .thenReturn(committer)
-        .thenThrow(new IllegalStateException("should only init once"));
-    MultiPartitionCommitterImpl multiCommitter =
-        new MultiPartitionCommitterImpl(1, (p) -> committer);
-
-    PslSourceOffset offset =
-        PslSourceOffset.builder()
-            .partitionOffsetMap(ImmutableMap.of(Partition.of(0), Offset.of(10L)))
-            .build();
-    SettableApiFuture<Void> future1 = SettableApiFuture.create();
-    when(committer.commitOffset(eq(Offset.of(10L)))).thenReturn(future1);
-    when(committer.stopAsync()).thenReturn(committer);
-    multiCommitter.commit(offset);
-
-    multiCommitter.close();
-    verify(committer, times(1)).stopAsync();
-  }
-
-  @Test
-  public void testPartitionChange() {
-    List<Committer> committers = new ArrayList<>();
-    for (int i = 0; i < 4; i++) {
+  private MultiPartitionCommitterImpl createCommitter(int initialPartitions, int available) {
+    committerList = new ArrayList<>();
+    for (int i = 0; i < available; i++) {
       Committer committer = mock(Committer.class);
       when(committer.startAsync())
           .thenReturn(committer)
           .thenThrow(new IllegalStateException("should only init once"));
       when(committer.commitOffset(eq(Offset.of(10L)))).thenReturn(SettableApiFuture.create());
-      committers.add(committer);
+      committerList.add(committer);
     }
+    ScheduledExecutorService mockExecutor = mock(ScheduledExecutorService.class);
+    ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+    when(mockExecutor.scheduleWithFixedDelay(
+            taskCaptor.capture(), anyLong(), anyLong(), any(TimeUnit.class)))
+        .thenReturn(null);
     MultiPartitionCommitterImpl multiCommitter =
-        new MultiPartitionCommitterImpl(2, p -> committers.get((int) p.value()));
+        new MultiPartitionCommitterImpl(
+            initialPartitions, p -> committerList.get((int) p.value()), mockExecutor);
+    task = taskCaptor.getValue();
+    return multiCommitter;
+  }
+
+  private MultiPartitionCommitterImpl createCommitter(int initialPartitions) {
+    return createCommitter(initialPartitions, initialPartitions);
+  }
+
+  @Test
+  public void testCommit() {
+    MultiPartitionCommitterImpl multiCommitter = createCommitter(2);
+
+    verify(committerList.get(0)).startAsync();
+    verify(committerList.get(1)).startAsync();
+
+    PslSourceOffset offset = createPslSourceOffset(10L, 8L);
+    SettableApiFuture<Void> future1 = SettableApiFuture.create();
+    SettableApiFuture<Void> future2 = SettableApiFuture.create();
+    when(committerList.get(0).commitOffset(eq(Offset.of(10L)))).thenReturn(future1);
+    when(committerList.get(1).commitOffset(eq(Offset.of(8L)))).thenReturn(future2);
+    multiCommitter.commit(offset);
+    verify(committerList.get(0)).commitOffset(eq(Offset.of(10L)));
+    verify(committerList.get(1)).commitOffset(eq(Offset.of(8L)));
+  }
+
+  @Test
+  public void testClose() {
+    MultiPartitionCommitterImpl multiCommitter = createCommitter(1);
+
+    PslSourceOffset offset = createPslSourceOffset(10L);
+    SettableApiFuture<Void> future1 = SettableApiFuture.create();
+    when(committerList.get(0).commitOffset(eq(Offset.of(10L)))).thenReturn(future1);
+    multiCommitter.commit(offset);
+    when(committerList.get(0).stopAsync()).thenReturn(committerList.get(0));
+
+    multiCommitter.close();
+    verify(committerList.get(0)).stopAsync();
+  }
+
+  @Test
+  public void testPartitionChange() {
+    // Creates committer with 2 partitions
+    MultiPartitionCommitterImpl multiCommitter = createCommitter(2, 4);
     for (int i = 0; i < 2; i++) {
-      verify(committers.get(i)).startAsync();
+      verify(committerList.get(i)).startAsync();
     }
     for (int i = 2; i < 4; i++) {
-      verify(committers.get(i), times(0)).startAsync();
+      verify(committerList.get(i), times(0)).startAsync();
     }
 
     // Partitions increased to 4.
-    PslSourceOffset offset =
-        PslSourceOffset.builder()
-            .partitionOffsetMap(
-                ImmutableMap.of(
-                    Partition.of(0), Offset.of(10L),
-                    Partition.of(1), Offset.of(10L),
-                    Partition.of(2), Offset.of(10L),
-                    Partition.of(3), Offset.of(10L)))
-            .build();
-    multiCommitter.commit(offset);
+    multiCommitter.commit(createPslSourceOffset(10L, 10L, 10L, 10L));
     for (int i = 0; i < 2; i++) {
-      verify(committers.get(i)).commitOffset(eq(Offset.of(10L)));
+      verify(committerList.get(i)).commitOffset(eq(Offset.of(10L)));
     }
     for (int i = 2; i < 4; i++) {
-      verify(committers.get(i)).startAsync();
-      verify(committers.get(i)).commitOffset(eq(Offset.of(10L)));
+      verify(committerList.get(i)).startAsync();
+      verify(committerList.get(i)).commitOffset(eq(Offset.of(10L)));
     }
+
+    // Partitions decreased to 2
+    multiCommitter.commit(createPslSourceOffset(10L, 10L));
+    for (int i = 0; i < 2; i++) {
+      verify(committerList.get(i), times(2)).commitOffset(eq(Offset.of(10L)));
+    }
+    task.run();
+    for (int i = 2; i < 4; i++) {
+      verify(committerList.get(i)).stopAsync();
+    }
+  }
+
+  @Test
+  public void testDelayedPartitionRemoval() {
+    // Creates committer with 4 partitions, then decrease to 2, then increase to 3.
+    MultiPartitionCommitterImpl multiCommitter = createCommitter(4);
+    multiCommitter.commit(createPslSourceOffset(10L, 10L));
+    multiCommitter.commit(createPslSourceOffset(10L, 10L, 10L));
+    task.run();
+    verify(committerList.get(2)).startAsync();
+    verify(committerList.get(2), times(0)).stopAsync();
+    verify(committerList.get(3)).startAsync();
+    verify(committerList.get(3)).stopAsync();
   }
 }

--- a/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.pubsublite.spark;
 
+import static com.google.cloud.pubsublite.spark.TestingUtils.createPslSourceOffset;
+import static com.google.cloud.pubsublite.spark.TestingUtils.createSparkSourceOffset;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -27,8 +29,6 @@ import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.internal.CursorClient;
 import com.google.cloud.pubsublite.internal.testing.UnitTestExamples;
 import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -52,25 +52,6 @@ public class PslMicroBatchReaderTest {
           UnitTestExamples.exampleSubscriptionPath(),
           OPTIONS.flowControlSettings(),
           MAX_MESSAGES_PER_BATCH);
-
-  private PslSourceOffset createPslSourceOffset(long... offsets) {
-    Map<Partition, Offset> map = new HashMap<>();
-    int idx = 0;
-    for (long offset : offsets) {
-      map.put(Partition.of(idx++), Offset.of(offset));
-    }
-    return PslSourceOffset.builder().partitionOffsetMap(map).build();
-  }
-
-  private SparkSourceOffset createSparkSourceOffset(long... offsets) {
-    Map<Partition, SparkPartitionOffset> map = new HashMap<>();
-    int idx = 0;
-    for (long offset : offsets) {
-      map.put(Partition.of(idx), SparkPartitionOffset.create(Partition.of(idx), offset));
-      idx++;
-    }
-    return new SparkSourceOffset(map);
-  }
 
   @Test
   public void testNoCommitCursors() {

--- a/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/PslMicroBatchReaderTest.java
@@ -27,6 +27,8 @@ import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.internal.CursorClient;
 import com.google.cloud.pubsublite.internal.testing.UnitTestExamples;
 import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -49,31 +51,52 @@ public class PslMicroBatchReaderTest {
           headOffsetReader,
           UnitTestExamples.exampleSubscriptionPath(),
           OPTIONS.flowControlSettings(),
-          MAX_MESSAGES_PER_BATCH,
-          2);
+          MAX_MESSAGES_PER_BATCH);
 
-  private PslSourceOffset createPslSourceOffsetTwoPartition(long offset0, long offset1) {
-    return PslSourceOffset.builder()
-        .partitionOffsetMap(
-            ImmutableMap.of(
-                Partition.of(0L), Offset.of(offset0), Partition.of(1L), Offset.of(offset1)))
-        .build();
+  private PslSourceOffset createPslSourceOffset(long... offsets) {
+    Map<Partition, Offset> map = new HashMap<>();
+    int idx = 0;
+    for (long offset : offsets) {
+      map.put(Partition.of(idx++), Offset.of(offset));
+    }
+    return PslSourceOffset.builder().partitionOffsetMap(map).build();
   }
 
-  private SparkSourceOffset createSparkSourceOffsetTwoPartition(long offset0, long offset1) {
-    return new SparkSourceOffset(
-        ImmutableMap.of(
+  private SparkSourceOffset createSparkSourceOffset(long... offsets) {
+    Map<Partition, SparkPartitionOffset> map = new HashMap<>();
+    int idx = 0;
+    for (long offset : offsets) {
+      map.put(Partition.of(idx), SparkPartitionOffset.create(Partition.of(idx), offset));
+      idx++;
+    }
+    return new SparkSourceOffset(map);
+  }
+
+  @Test
+  public void testNoCommitCursors() {
+    when(cursorClient.listPartitionCursors(UnitTestExamples.exampleSubscriptionPath()))
+        .thenReturn(ApiFutures.immediateFuture(ImmutableMap.of()));
+    when(headOffsetReader.getHeadOffset()).thenReturn(createPslSourceOffset(301L, 200L));
+    reader.setOffsetRange(Optional.empty(), Optional.empty());
+    assertThat(((SparkSourceOffset) reader.getStartOffset()).getPartitionOffsetMap())
+        .containsExactly(
             Partition.of(0L),
-            SparkPartitionOffset.create(Partition.of(0L), offset0),
+            SparkPartitionOffset.create(Partition.of(0L), -1L),
             Partition.of(1L),
-            SparkPartitionOffset.create(Partition.of(1L), offset1)));
+            SparkPartitionOffset.create(Partition.of(1L), -1L));
+    assertThat(((SparkSourceOffset) reader.getEndOffset()).getPartitionOffsetMap())
+        .containsExactly(
+            Partition.of(0L),
+            SparkPartitionOffset.create(Partition.of(0L), 300L),
+            Partition.of(1L),
+            SparkPartitionOffset.create(Partition.of(1L), 199L));
   }
 
   @Test
   public void testEmptyOffsets() {
     when(cursorClient.listPartitionCursors(UnitTestExamples.exampleSubscriptionPath()))
         .thenReturn(ApiFutures.immediateFuture(ImmutableMap.of(Partition.of(0L), Offset.of(100L))));
-    when(headOffsetReader.getHeadOffset()).thenReturn(createPslSourceOffsetTwoPartition(301L, 0L));
+    when(headOffsetReader.getHeadOffset()).thenReturn(createPslSourceOffset(301L, 0L));
     reader.setOffsetRange(Optional.empty(), Optional.empty());
     assertThat(((SparkSourceOffset) reader.getStartOffset()).getPartitionOffsetMap())
         .containsExactly(
@@ -91,8 +114,8 @@ public class PslMicroBatchReaderTest {
 
   @Test
   public void testValidOffsets() {
-    SparkSourceOffset startOffset = createSparkSourceOffsetTwoPartition(10L, 100L);
-    SparkSourceOffset endOffset = createSparkSourceOffsetTwoPartition(20L, 300L);
+    SparkSourceOffset startOffset = createSparkSourceOffset(10L, 100L);
+    SparkSourceOffset endOffset = createSparkSourceOffset(20L, 300L);
     reader.setOffsetRange(Optional.of(startOffset), Optional.of(endOffset));
     assertThat(reader.getStartOffset()).isEqualTo(startOffset);
     assertThat(reader.getEndOffset()).isEqualTo(endOffset);
@@ -108,16 +131,16 @@ public class PslMicroBatchReaderTest {
 
   @Test
   public void testCommit() {
-    SparkSourceOffset offset = createSparkSourceOffsetTwoPartition(10L, 50L);
-    PslSourceOffset expectedCommitOffset = createPslSourceOffsetTwoPartition(11L, 51L);
+    SparkSourceOffset offset = createSparkSourceOffset(10L, 50L);
+    PslSourceOffset expectedCommitOffset = createPslSourceOffset(11L, 51L);
     reader.commit(offset);
     verify(committer, times(1)).commit(eq(expectedCommitOffset));
   }
 
   @Test
   public void testPlanInputPartitionNoMessage() {
-    SparkSourceOffset startOffset = createSparkSourceOffsetTwoPartition(10L, 100L);
-    SparkSourceOffset endOffset = createSparkSourceOffsetTwoPartition(20L, 100L);
+    SparkSourceOffset startOffset = createSparkSourceOffset(10L, 100L);
+    SparkSourceOffset endOffset = createSparkSourceOffset(20L, 100L);
     reader.setOffsetRange(Optional.of(startOffset), Optional.of(endOffset));
     assertThat(reader.planInputPartitions()).hasSize(1);
   }
@@ -126,8 +149,7 @@ public class PslMicroBatchReaderTest {
   public void testMaxMessagesPerBatch() {
     when(cursorClient.listPartitionCursors(UnitTestExamples.exampleSubscriptionPath()))
         .thenReturn(ApiFutures.immediateFuture(ImmutableMap.of(Partition.of(0L), Offset.of(100L))));
-    when(headOffsetReader.getHeadOffset())
-        .thenReturn(createPslSourceOffsetTwoPartition(10000000L, 0L));
+    when(headOffsetReader.getHeadOffset()).thenReturn(createPslSourceOffset(10000000L, 0L));
     reader.setOffsetRange(Optional.empty(), Optional.empty());
     assertThat(((SparkSourceOffset) reader.getEndOffset()).getPartitionOffsetMap())
         .containsExactly(
@@ -138,5 +160,53 @@ public class PslMicroBatchReaderTest {
             SparkPartitionOffset.create(Partition.of(0L), 100L + MAX_MESSAGES_PER_BATCH - 1L),
             Partition.of(1L),
             SparkPartitionOffset.create(Partition.of(1L), -1L));
+  }
+
+  @Test
+  public void testPartitionIncreasedRetry() {
+    SparkSourceOffset startOffset = createSparkSourceOffset(10L, 100L);
+    SparkSourceOffset endOffset = createSparkSourceOffset(20L, 300L, 100L);
+    reader.setOffsetRange(Optional.of(startOffset), Optional.of(endOffset));
+    assertThat(reader.getStartOffset()).isEqualTo(startOffset);
+    assertThat(reader.getEndOffset()).isEqualTo(endOffset);
+    assertThat(reader.planInputPartitions()).hasSize(3);
+  }
+
+  @Test
+  public void testPartitionIncreasedNewQuery() {
+    when(cursorClient.listPartitionCursors(UnitTestExamples.exampleSubscriptionPath()))
+        .thenReturn(ApiFutures.immediateFuture(ImmutableMap.of(Partition.of(0L), Offset.of(100L))));
+    SparkSourceOffset endOffset = createSparkSourceOffset(301L, 200L);
+    when(headOffsetReader.getHeadOffset()).thenReturn(PslSparkUtils.toPslSourceOffset(endOffset));
+    reader.setOffsetRange(Optional.empty(), Optional.empty());
+    assertThat(reader.getStartOffset()).isEqualTo(createSparkSourceOffset(99L, -1L));
+    assertThat(reader.getEndOffset()).isEqualTo(endOffset);
+    assertThat(reader.planInputPartitions()).hasSize(2);
+  }
+
+  @Test
+  public void testPartitionIncreasedBeforeSetOffsets() {
+    SparkSourceOffset endOffset = createSparkSourceOffset(301L, 200L);
+    SparkSourceOffset startOffset = createSparkSourceOffset(100L);
+    when(headOffsetReader.getHeadOffset()).thenReturn(PslSparkUtils.toPslSourceOffset(endOffset));
+    reader.setOffsetRange(Optional.of(startOffset), Optional.empty());
+    assertThat(reader.getStartOffset()).isEqualTo(startOffset);
+    assertThat(reader.getEndOffset()).isEqualTo(endOffset);
+    assertThat(reader.planInputPartitions()).hasSize(2);
+  }
+
+  @Test
+  public void testPartitionIncreasedBetweenSetOffsetsAndPlan() {
+    SparkSourceOffset startOffset = createSparkSourceOffset(100L);
+    SparkSourceOffset endOffset = createSparkSourceOffset(301L);
+    SparkSourceOffset newEndOffset = createSparkSourceOffset(600L, 300L);
+    when(headOffsetReader.getHeadOffset()).thenReturn(PslSparkUtils.toPslSourceOffset(endOffset));
+    reader.setOffsetRange(Optional.of(startOffset), Optional.empty());
+    assertThat(reader.getStartOffset()).isEqualTo(startOffset);
+    assertThat(reader.getEndOffset()).isEqualTo(endOffset);
+    when(headOffsetReader.getHeadOffset())
+        .thenReturn(PslSparkUtils.toPslSourceOffset(newEndOffset));
+    // headOffsetReader changes between setOffsets and plan should have no effect.
+    assertThat(reader.planInputPartitions()).hasSize(1);
   }
 }

--- a/src/test/java/com/google/cloud/pubsublite/spark/TestingUtils.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/TestingUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.pubsublite.spark;
 
 import com.google.cloud.pubsublite.Offset;

--- a/src/test/java/com/google/cloud/pubsublite/spark/TestingUtils.java
+++ b/src/test/java/com/google/cloud/pubsublite/spark/TestingUtils.java
@@ -1,0 +1,27 @@
+package com.google.cloud.pubsublite.spark;
+
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.Partition;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestingUtils {
+  public static PslSourceOffset createPslSourceOffset(long... offsets) {
+    Map<Partition, Offset> map = new HashMap<>();
+    int idx = 0;
+    for (long offset : offsets) {
+      map.put(Partition.of(idx++), Offset.of(offset));
+    }
+    return PslSourceOffset.builder().partitionOffsetMap(map).build();
+  }
+
+  public static SparkSourceOffset createSparkSourceOffset(long... offsets) {
+    Map<Partition, SparkPartitionOffset> map = new HashMap<>();
+    int idx = 0;
+    for (long offset : offsets) {
+      map.put(Partition.of(idx), SparkPartitionOffset.create(Partition.of(idx), offset));
+      idx++;
+    }
+    return new SparkSourceOffset(map);
+  }
+}


### PR DESCRIPTION
This adds support for topic partition increase for both micro batch and continuous mode.

`CachedPartitionCountReader` is used to cache the number of topic partitions and fetches once every 10s, that should be well within the limit (admin read limit is 600/min). Spark doesn't need a consistent read for it to work as long as it's eventually consistent.

For micro batch, the `CachedPartitionCountReader` is embedded inside HeadOffsetReader, and inside the lifecycle of each batch, as soon as the topic partition is read, this will serve as _the_ topic partition across the whole lifecycle of this batch. It's implicitly embedded in the `endOffset`.

For continuous, a topic partition number is set once a ContinuousReader, and once `needsReconfiguration()` detects an updated value, Spark will reconstruct a new ContinuousReader with the updated value.