### PR TITLE
chore: allow lite team members to manage the repo

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -46,5 +46,5 @@ permissionRules:
   permission: admin
 - team: yoshi-java
   permission: push
-- team: api-pubsub
+- team: api-pubsublite
   permission: admin


### PR DESCRIPTION
Members in https://github.com/orgs/googleapis/teams/api-pubsublite are admins of the repo now. 

This GitHub Team Sync team is mapped to the internal Lite Dev team. 