### PR TITLE
deps: update to google-cloud-pubsublite to v0.15.0

### DIFF
--- a/clirr-ignored-differences.xml
+++ b/clirr-ignored-differences.xml
@@ -3,6 +3,11 @@
 <differences>
     <difference>
         <differenceType>7004</differenceType>
+        <className>com/google/cloud/pubsublite/spark/internal/*</className>
+        <method>*</method>
+    </difference>
+    <difference>
+        <differenceType>7004</differenceType>
         <className>com/google/cloud/pubsublite/spark/*Reader</className>
         <method>*</method>
     </difference>
@@ -13,16 +18,18 @@
         <to>*</to>
     </difference>
     <difference>
+        <differenceType>7005</differenceType>
+        <className>com/google/cloud/pubsublite/spark/*InputPartition</className>
+        <method>*</method>
+        <to>*</to>
+    </difference>
+    <difference>
         <differenceType>8001</differenceType>
         <className>com/google/cloud/pubsublite/spark/LimitingHeadOffsetReader</className>
     </difference>
     <difference>
         <differenceType>8001</differenceType>
         <className>com/google/cloud/pubsublite/spark/MultiPartitionCommitter*</className>
-    </difference>
-    <difference>
-        <differenceType>8001</differenceType>
-        <className>com/google/cloud/pubsublite/spark/PartitionSubscriberFactory</className>
     </difference>
     <difference>
         <differenceType>8001</differenceType>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
-      <version>0.14.2</version>
+      <version>0.15.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslContinuousReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslContinuousReader.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.cloud.pubsublite.internal.CursorClient;
-import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
 import com.google.cloud.pubsublite.spark.internal.MultiPartitionCommitter;
 import com.google.cloud.pubsublite.spark.internal.PartitionCountReader;
 import com.google.cloud.pubsublite.spark.internal.PartitionSubscriberFactory;
@@ -116,12 +115,9 @@ public class PslContinuousReader implements ContinuousReader {
   public List<InputPartition<InternalRow>> planInputPartitions() {
     List<InputPartition<InternalRow>> list = new ArrayList<>();
     for (SparkPartitionOffset offset : startOffset.getPartitionOffsetMap().values()) {
-      PartitionSubscriberFactory partitionSubscriberFactory = this.partitionSubscriberFactory;
-      SubscriberFactory subscriberFactory =
-          (consumer) -> partitionSubscriberFactory.newSubscriber(offset.partition(), consumer);
       list.add(
           new PslContinuousInputPartition(
-              subscriberFactory,
+              partitionSubscriberFactory,
               SparkPartitionOffset.builder()
                   .partition(offset.partition())
                   .offset(offset.offset())

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
@@ -23,7 +23,6 @@ import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.cloud.pubsublite.internal.CursorClient;
-import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
 import com.google.cloud.pubsublite.spark.internal.MultiPartitionCommitter;
 import com.google.cloud.pubsublite.spark.internal.PartitionSubscriberFactory;
 import com.google.cloud.pubsublite.spark.internal.PerTopicHeadOffsetReader;
@@ -145,17 +144,13 @@ public class PslMicroBatchReader implements MicroBatchReader {
         // There is no message to pull for this partition.
         continue;
       }
-      PartitionSubscriberFactory partitionSubscriberFactory = this.partitionSubscriberFactory;
-      SubscriberFactory subscriberFactory =
-          (consumer) ->
-              partitionSubscriberFactory.newSubscriber(endPartitionOffset.partition(), consumer);
       list.add(
           new PslMicroBatchInputPartition(
               subscriptionPath,
               flowControlSettings,
               startPartitionOffset,
               endPartitionOffset,
-              subscriberFactory));
+              partitionSubscriberFactory));
     }
     return list;
   }

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslReadDataSourceOptions.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslReadDataSourceOptions.java
@@ -155,7 +155,7 @@ public abstract class PslReadDataSourceOptions implements Serializable {
             .setMessageConsumer(consumer)
             .setInitialLocation(
                 SeekRequest.newBuilder()
-                    .setCursor(Cursor.newBuilder().setOffset(offset.value()).build())
+                    .setCursor(Cursor.newBuilder().setOffset(offset.value()))
                     .build())
             .build();
       } catch (IOException e) {

--- a/src/main/java/com/google/cloud/pubsublite/spark/PslReadDataSourceOptions.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/PslReadDataSourceOptions.java
@@ -33,6 +33,8 @@ import com.google.cloud.pubsublite.internal.wire.PubsubContext;
 import com.google.cloud.pubsublite.internal.wire.RoutingMetadata;
 import com.google.cloud.pubsublite.internal.wire.ServiceClients;
 import com.google.cloud.pubsublite.internal.wire.SubscriberBuilder;
+import com.google.cloud.pubsublite.proto.Cursor;
+import com.google.cloud.pubsublite.proto.SeekRequest;
 import com.google.cloud.pubsublite.spark.internal.MultiPartitionCommitter;
 import com.google.cloud.pubsublite.spark.internal.MultiPartitionCommitterImpl;
 import com.google.cloud.pubsublite.spark.internal.PartitionSubscriberFactory;
@@ -135,7 +137,7 @@ public abstract class PslReadDataSourceOptions implements Serializable {
   }
 
   PartitionSubscriberFactory getSubscriberFactory() {
-    return (partition, consumer) -> {
+    return (partition, offset, consumer) -> {
       PubsubContext context = PubsubContext.of(Constants.FRAMEWORK);
       SubscriberServiceSettings.Builder settingsBuilder =
           SubscriberServiceSettings.newBuilder()
@@ -151,6 +153,10 @@ public abstract class PslReadDataSourceOptions implements Serializable {
             .setPartition(partition)
             .setServiceClient(serviceClient)
             .setMessageConsumer(consumer)
+            .setInitialLocation(
+                SeekRequest.newBuilder()
+                    .setCursor(Cursor.newBuilder().setOffset(offset.value()).build())
+                    .build())
             .build();
       } catch (IOException e) {
         throw new IllegalStateException("Failed to create subscriber service.", e);

--- a/src/main/java/com/google/cloud/pubsublite/spark/internal/PartitionSubscriberFactory.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/internal/PartitionSubscriberFactory.java
@@ -17,6 +17,7 @@
 package com.google.cloud.pubsublite.spark.internal;
 
 import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.pubsublite.Offset;
 import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.SequencedMessage;
 import com.google.cloud.pubsublite.internal.wire.Subscriber;
@@ -26,6 +27,8 @@ import java.util.function.Consumer;
 
 public interface PartitionSubscriberFactory extends Serializable {
   Subscriber newSubscriber(
-      Partition partition, Consumer<ImmutableList<SequencedMessage>> message_consumer)
+      Partition partition,
+      Offset offset,
+      Consumer<ImmutableList<SequencedMessage>> message_consumer)
       throws ApiException;
 }


### PR DESCRIPTION
Manual update to handle the interface change of `BlockingPullSubscriberImpl` - the `SubscriberBuilder` now accepts an initial location when connecting a new Subscribe stream and an additional seek request is not necessary.

An offset parameter was added to `PartitionSubscriberFactory` in order to pass the initiation offset through to `SubscriberBuilder`.