### PR TITLE
deps: update dependency com.google.cloud:google-cloud-pubsublite to v0.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
-      <version>0.15.0</version>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
-      <version>0.14.2</version>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
-      <version>0.14.2</version>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/google/cloud/pubsublite/spark/internal/PartitionSubscriberFactory.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/internal/PartitionSubscriberFactory.java
@@ -27,8 +27,6 @@ import java.util.function.Consumer;
 
 public interface PartitionSubscriberFactory extends Serializable {
   Subscriber newSubscriber(
-      Partition partition,
-      Offset offset,
-      Consumer<List<SequencedMessage>> message_consumer)
+      Partition partition, Offset offset, Consumer<List<SequencedMessage>> message_consumer)
       throws ApiException;
 }

--- a/src/main/java/com/google/cloud/pubsublite/spark/internal/PartitionSubscriberFactory.java
+++ b/src/main/java/com/google/cloud/pubsublite/spark/internal/PartitionSubscriberFactory.java
@@ -21,14 +21,14 @@ import com.google.cloud.pubsublite.Offset;
 import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.SequencedMessage;
 import com.google.cloud.pubsublite.internal.wire.Subscriber;
-import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
+import java.util.List;
 import java.util.function.Consumer;
 
 public interface PartitionSubscriberFactory extends Serializable {
   Subscriber newSubscriber(
       Partition partition,
       Offset offset,
-      Consumer<ImmutableList<SequencedMessage>> message_consumer)
+      Consumer<List<SequencedMessage>> message_consumer)
       throws ApiException;
 }


### PR DESCRIPTION
Replaces https://github.com/googleapis/java-pubsublite-spark/pull/200