### PR TITLE
samples(tests): single use cluster

### DIFF
--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -47,6 +47,11 @@
       <version>1.5.4</version>
     </dependency>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-dataproc</artifactId>
+      <version>3.0.4</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
@@ -67,11 +72,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-dataproc</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -47,6 +47,10 @@
       <version>1.5.4</version>
     </dependency>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-dataproc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
@@ -67,11 +71,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-dataproc</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-dataproc</artifactId>
+      <version>3.0.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/samples/snippets/src/main/java/pubsublite/spark/AdminUtils.java
+++ b/samples/snippets/src/main/java/pubsublite/spark/AdminUtils.java
@@ -26,6 +26,7 @@ import com.google.cloud.dataproc.v1.ClusterConfig;
 import com.google.cloud.dataproc.v1.ClusterControllerClient;
 import com.google.cloud.dataproc.v1.ClusterControllerSettings;
 import com.google.cloud.dataproc.v1.ClusterOperationMetadata;
+import com.google.cloud.dataproc.v1.GceClusterConfig;
 import com.google.cloud.dataproc.v1.InstanceGroupConfig;
 import com.google.cloud.dataproc.v1.SoftwareConfig;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
@@ -310,11 +311,16 @@ public class AdminUtils {
               .build();
       SoftwareConfig softwareConfig =
           SoftwareConfig.newBuilder().setImageVersion(imageVersion).build();
+      GceClusterConfig gceClusterConfig =
+          GceClusterConfig.newBuilder()
+              .addServiceAccountScopes("https://www.googleapis.com/auth/cloud-platform")
+              .build();
       ClusterConfig clusterConfig =
           ClusterConfig.newBuilder()
               .setMasterConfig(masterConfig)
               .setWorkerConfig(workerConfig)
               .setSoftwareConfig(softwareConfig)
+              .setGceClusterConfig(gceClusterConfig)
               .build();
       // Create the cluster object with the desired cluster config.
       Cluster cluster =

--- a/samples/snippets/src/test/java/pubsublite/spark/SampleTestBase.java
+++ b/samples/snippets/src/test/java/pubsublite/spark/SampleTestBase.java
@@ -100,7 +100,7 @@ public abstract class SampleTestBase {
     projectId = ProjectId.of(env.get(PROJECT_ID));
     projectNumber = ProjectNumber.of(Long.parseLong(env.get(PROJECT_NUMBER)));
     sourceTopicId = TopicName.of(env.get(TOPIC_ID));
-    clusterName = env.get(CLUSTER_NAME) + "-" + runId.substring(0,16);
+    clusterName = env.get(CLUSTER_NAME) + "-" + runId.substring(0, 16);
     bucketName = env.get(BUCKET_NAME);
   }
 

--- a/samples/snippets/src/test/java/pubsublite/spark/SampleTestBase.java
+++ b/samples/snippets/src/test/java/pubsublite/spark/SampleTestBase.java
@@ -100,7 +100,7 @@ public abstract class SampleTestBase {
     projectId = ProjectId.of(env.get(PROJECT_ID));
     projectNumber = ProjectNumber.of(Long.parseLong(env.get(PROJECT_NUMBER)));
     sourceTopicId = TopicName.of(env.get(TOPIC_ID));
-    clusterName = env.get(CLUSTER_NAME) + runId;
+    clusterName = env.get(CLUSTER_NAME) + "-" + runId.substring(0,16);
     bucketName = env.get(BUCKET_NAME);
   }
 

--- a/samples/snippets/src/test/java/pubsublite/spark/SampleTestBase.java
+++ b/samples/snippets/src/test/java/pubsublite/spark/SampleTestBase.java
@@ -100,7 +100,7 @@ public abstract class SampleTestBase {
     projectId = ProjectId.of(env.get(PROJECT_ID));
     projectNumber = ProjectNumber.of(Long.parseLong(env.get(PROJECT_NUMBER)));
     sourceTopicId = TopicName.of(env.get(TOPIC_ID));
-    clusterName = env.get(CLUSTER_NAME);
+    clusterName = env.get(CLUSTER_NAME) + runId;
     bucketName = env.get(BUCKET_NAME);
   }
 

--- a/samples/snippets/src/test/java/pubsublite/spark/SamplesIntegrationTest.java
+++ b/samples/snippets/src/test/java/pubsublite/spark/SamplesIntegrationTest.java
@@ -23,7 +23,15 @@ import static pubsublite.spark.AdminUtils.deleteSubscriptionExample;
 import static pubsublite.spark.AdminUtils.deleteTopicExample;
 import static pubsublite.spark.AdminUtils.subscriberExample;
 
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.dataproc.v1.Cluster;
+import com.google.cloud.dataproc.v1.ClusterConfig;
+import com.google.cloud.dataproc.v1.ClusterControllerClient;
+import com.google.cloud.dataproc.v1.ClusterControllerSettings;
+import com.google.cloud.dataproc.v1.ClusterOperationMetadata;
+import com.google.cloud.dataproc.v1.InstanceGroupConfig;
 import com.google.cloud.dataproc.v1.Job;
+import com.google.cloud.dataproc.v1.SoftwareConfig;
 import com.google.cloud.dataproc.v1.SparkJob;
 import com.google.cloud.pubsublite.SubscriptionName;
 import com.google.cloud.pubsublite.SubscriptionPath;
@@ -38,8 +46,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -53,6 +63,8 @@ public class SamplesIntegrationTest extends SampleTestBase {
   private TopicPath destinationTopicPath;
   private SubscriptionName destinationSubscriptionName;
   private SubscriptionPath destinationSubscriptionPath;
+  private String myEndpoint = String.format("%s-dataproc.googleapis.com:443", cloudRegion);
+  private String imageVersion = "1.5-debian10";
   private Boolean initialized = false;
 
   @Before
@@ -75,6 +87,53 @@ public class SamplesIntegrationTest extends SampleTestBase {
     uploadGCS(storage, sampleJarNameInGCS, sampleJarLoc);
     uploadGCS(storage, connectorJarNameInGCS, connectorJarLoc);
     initialized = true;
+
+    // Create a Dataproc cluster
+    ClusterControllerSettings clusterControllerSettings =
+        ClusterControllerSettings.newBuilder().setEndpoint(myEndpoint).build();
+    try (ClusterControllerClient clusterControllerClient =
+        ClusterControllerClient.create(clusterControllerSettings)) {
+      // Configure the settings for our cluster.
+      InstanceGroupConfig masterConfig =
+          InstanceGroupConfig.newBuilder()
+              .setMachineTypeUri("n1-standard-2")
+              .setNumInstances(1)
+              .build();
+      InstanceGroupConfig workerConfig =
+          InstanceGroupConfig.newBuilder()
+              .setMachineTypeUri("n1-standard-2")
+              .setNumInstances(2)
+              .build();
+      SoftwareConfig softwareConfig =
+          SoftwareConfig.newBuilder().setImageVersion(imageVersion).build();
+      ClusterConfig clusterConfig =
+          ClusterConfig.newBuilder()
+              .setMasterConfig(masterConfig)
+              .setWorkerConfig(workerConfig)
+              .setSoftwareConfig(softwareConfig)
+              .build();
+      Cluster cluster =
+          Cluster.newBuilder().setClusterName(clusterName).setConfig(clusterConfig).build();
+
+      OperationFuture<Cluster, ClusterOperationMetadata> createClusterAsyncRequest =
+          clusterControllerClient.createClusterAsync(
+              projectId.toString(), cloudRegion.toString(), cluster);
+      Cluster response = createClusterAsyncRequest.get();
+      System.out.printf("Cluster created successfully: %s", response.getClusterName());
+    } catch (ExecutionException e) {
+      System.err.println(String.format("Error creating cluster: %s ", e.getMessage()));
+    }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    // Delete the Dataproc cluster.
+    ClusterControllerSettings clusterControllerSettings =
+        ClusterControllerSettings.newBuilder().setEndpoint(myEndpoint).build();
+    ClusterControllerClient clusterControllerClient =
+        ClusterControllerClient.create(clusterControllerSettings);
+    clusterControllerClient.deleteClusterAsync(
+        projectId.toString(), cloudRegion.toString(), clusterName);
   }
 
   /** Note that source single word messages have been published to a permanent topic. */


### PR DESCRIPTION
Run samples tests to a single-use cluster instead of a permanent cluster. 

To run tests on a cluster of a different Spark version, update `imageVersion`.

More details: https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions