### PR TITLE
Chore: Skip clirr check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <url>https://github.com/googleapis/java-pubsublite-spark</url>
   <description>Spark SQL Streaming Connector for Google Cloud Pub/Sub Lite</description>
   <properties>
+    <clirr.skip>true</clirr.skip>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <url>https://github.com/googleapis/java-pubsublite-spark</url>
   <description>Spark SQL Streaming Connector for Google Cloud Pub/Sub Lite</description>
   <properties>
+    <!--clirr is disabled in the parent pom-->
     <clirr.skip>true</clirr.skip>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
`mvn clean verify` fails at the clirr check with compilation error unrelated to this library
